### PR TITLE
Add shared RGBA opener for patched spriterig script

### DIFF
--- a/apply_patches_mintravy.py
+++ b/apply_patches_mintravy.py
@@ -33,7 +33,13 @@ from dataclasses import dataclass
 from typing import Tuple, Dict, List, Optional
 
 # Safety: avoid decompression bombs for mistakenly large images
-Image.MAX_IMAGE_PIXELS = 64_000_000  # ~64MP
+Image.MAX_IMAGE_PIXELS = 64_000_000  # P5: safety bound
+
+def _open_rgba(path):
+    try:
+        return Image.open(path).convert('RGBA')
+    except Exception as e:
+        raise SystemExit(f"[error] failed to open image '{path}': {e}")
 
 @dataclass
 class TileSpec:
@@ -223,10 +229,7 @@ def main(argv: List[str]) -> None:
     elif args.cmd == "validate":
         tile = TileSpec(*args.tile)
         sheet = SheetSpec(*args.sheet)
-        try:
-            img = Image.open(args.image).convert("RGBA")
-        except Exception as e:
-            raise SystemExit(f"[error] failed to open image '{args.image}': {e}")
+        img = _open_rgba(args.image)
         ok, report = validate_sheet(img, tile, sheet)
         print(json.dumps(report, indent=2))
         if not ok:
@@ -265,10 +268,7 @@ def main(argv: List[str]) -> None:
 
         r = c = 0
         for fp in frames:
-            try:
-                fr = Image.open(fp).convert("RGBA")
-            except Exception as e:
-                raise SystemExit(f"[error] failed to open frame '{fp}': {e}")
+            fr = _open_rgba(fp)
             base = os.path.basename(fp)
             pm = pivot_map.get(base)
             frame_pivot = tuple(pm) if isinstance(pm, (list, tuple)) and len(pm) == 2 else None
@@ -281,19 +281,13 @@ def main(argv: List[str]) -> None:
 
     elif args.cmd == "gif":
         tile = TileSpec(*args.tile)
-        try:
-            img = Image.open(args.image).convert("RGBA")
-        except Exception as e:
-            raise SystemExit(f"[error] failed to open image '{args.image}': {e}")
+        img = _open_rgba(args.image)
         gif_from_row(img, tile, args.row, args.frames, args.out, args.ms)
         print("Wrote %s" % args.out)
 
     elif args.cmd == "slice":
         tile = TileSpec(*args.tile); sheet = SheetSpec(*args.sheet)
-        try:
-            img = Image.open(args.image).convert("RGBA")
-        except Exception as e:
-            raise SystemExit(f"[error] failed to open image '{args.image}': {e}")
+        img = _open_rgba(args.image)
         os.makedirs(args.outdir, exist_ok=True)
         for r in range(sheet.rows):
             for c in range(sheet.cols):


### PR DESCRIPTION
## Summary
- add a shared `_open_rgba` helper to the bundled spriterig implementation
- replace ad-hoc PIL open+convert calls with the helper to ensure consistent error messaging

## Testing
- python -m compileall apply_patches_mintravy.py

------
https://chatgpt.com/codex/tasks/task_b_68d1d28d2f40832e833273e25fc1bc62