### PR TITLE
Skip slow tests by default

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -m "not slow"
+markers =
+    slow: marks tests as slow (deselect with '-m "slow"')


### PR DESCRIPTION
## Summary
- add pytest configuration to register the slow marker and skip slow tests unless explicitly requested

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1de230678832ebc6c907472ff0f82