### PR TITLE
Add preset tuning utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # PixStu
+
+## Applications
+
+- `app/pixel_char_studio.py`: Main Pixel Character Studio interface for generating pixel-art renders from text prompts.
+- `app/preset_tuner.py`: Lightweight utility for adjusting curated preset defaults and previewing the effect of new inference settings.
+
+## Curated Presets
+
+Curated presets live in `configs/curated_models.json`. The preset tuner lets you tweak the recommended inference steps, guidance scale, and primary LoRA weight before saving the changes back to disk.
+
+To launch the tuner use:
+
+```bash
+python -m app.preset_tuner
+```
+
+The tool provides:
+
+- A dropdown to select the preset to edit.
+- Sliders for denoising steps, guidance scale, and LoRA weight.
+- Buttons to update the preset on disk or preview the difference between the existing and proposed values using a fixed seed.
+
+Preview renders use small 64×64 generations to keep iteration fast. When satisfied with the adjustments, press **Update Preset** to persist them.

--- a/app/preset_tuner.py
+++ b/app/preset_tuner.py
@@ -1,0 +1,193 @@
+import json
+import os
+import sys
+from typing import List, Optional, Tuple
+
+import gradio as gr
+import torch
+from diffusers import StableDiffusionXLPipeline
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
+PROJ = os.path.abspath(os.path.join(ROOT, ".."))
+EXE_DIR = os.path.dirname(sys.executable) if getattr(sys, "frozen", False) else PROJ
+MODELS_ROOT = os.getenv("PCS_MODELS_ROOT", os.path.join(EXE_DIR, "models"))
+PRESET_PATH = os.path.join(PROJ, "configs", "curated_models.json")
+
+
+def _abs_under_models(path: Optional[str]) -> Optional[str]:
+    if not path:
+        return path
+    if os.path.isabs(path):
+        return os.path.normpath(path)
+    return os.path.normpath(os.path.abspath(os.path.join(MODELS_ROOT, path)))
+
+
+def _device() -> Tuple[str, torch.dtype]:
+    if torch.cuda.is_available():
+        return "cuda", torch.float16
+    mps = getattr(torch.backends, "mps", None)
+    if mps and torch.backends.mps.is_available():  # pragma: no cover - environment specific
+        return "mps", torch.float16
+    return "cpu", torch.float32
+
+
+DEV, DTYPE = _device()
+
+
+def _load_presets() -> List[dict]:
+    if not os.path.isfile(PRESET_PATH):
+        return []
+    with open(PRESET_PATH, "r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    return payload.get("presets", [])
+
+
+PRESETS: List[dict] = _load_presets()
+
+
+def save_presets(presets: List[dict]) -> None:
+    os.makedirs(os.path.dirname(PRESET_PATH), exist_ok=True)
+    with open(PRESET_PATH, "w", encoding="utf-8") as fh:
+        json.dump({"presets": presets}, fh, indent=2)
+
+
+def _resolve_model_id(model_id: str) -> str:
+    if not model_id:
+        return "stabilityai/stable-diffusion-xl-base-1.0"
+    resolved = _abs_under_models(model_id)
+    if resolved and os.path.isdir(resolved):
+        return resolved
+    return model_id
+
+
+def update_preset(preset_name: str, steps: int, guidance: float, weight: float) -> str:
+    for preset in PRESETS:
+        if preset.get("name") == preset_name:
+            suggested = preset.setdefault("suggested", {})
+            suggested["steps"] = steps
+            suggested["guidance"] = guidance
+            if preset.get("loras"):
+                preset["loras"][0]["weight"] = weight
+            save_presets(PRESETS)
+            return (
+                f"Updated preset: {preset_name} with Steps={steps}, "
+                f"Guidance={guidance}, LoRA Weight={weight}"
+            )
+    return f"Preset '{preset_name}' not found"
+
+
+def _load_pipeline(preset: dict, weight: Optional[float] = None) -> StableDiffusionXLPipeline:
+    base_model = _resolve_model_id(preset.get("base_model"))
+    pipe = StableDiffusionXLPipeline.from_pretrained(
+        base_model,
+        torch_dtype=DTYPE,
+    )
+    if DEV != "cpu":
+        pipe.to(DEV)
+
+    loras = preset.get("loras") or []
+    if loras:
+        entry = loras[0]
+        lora_path = _abs_under_models(entry.get("path"))
+        if lora_path and os.path.exists(lora_path):
+            weight_to_use = weight if weight is not None else entry.get("weight", 1.0)
+            pipe.load_lora_weights(lora_path, weight=weight_to_use)
+    return pipe
+
+
+def preview_generation(
+    prompt: str,
+    preset_name: str,
+    steps: int,
+    guidance: float,
+    weight: float,
+    seed: int = 42,
+):
+    preset = next((p for p in PRESETS if p.get("name") == preset_name), None)
+    if not preset:
+        return None, None, "Preset not found"
+
+    generator_device = "cuda" if DEV == "cuda" else "cpu"
+
+    pipe_before = _load_pipeline(preset)
+    generator = torch.Generator(device=generator_device).manual_seed(seed)
+    before = pipe_before(
+        prompt=prompt or "pixel art character sprite",
+        num_inference_steps=preset.get("suggested", {}).get("steps", 20),
+        guidance_scale=preset.get("suggested", {}).get("guidance", 7.5),
+        generator=generator,
+        height=64,
+        width=64,
+    ).images[0]
+
+    pipe_after = _load_pipeline(preset, weight=weight)
+    generator = torch.Generator(device=generator_device).manual_seed(seed)
+    after = pipe_after(
+        prompt=prompt or "pixel art character sprite",
+        num_inference_steps=steps,
+        guidance_scale=guidance,
+        generator=generator,
+        height=64,
+        width=64,
+    ).images[0]
+
+    return before, after, "Preview before/after generated successfully"
+
+
+with gr.Blocks(analytics_enabled=False) as demo:
+    gr.Markdown("Curated Preset Tuner")
+    with gr.Row():
+        preset = gr.Dropdown([p.get("name") for p in PRESETS], label="Preset", info="Select which preset to tune.")
+    with gr.Row():
+        prompt = gr.Textbox(
+            label="Prompt",
+            info="Optional custom prompt for preview. Leave empty to use default.",
+        )
+    with gr.Row():
+        steps = gr.Slider(
+            5,
+            50,
+            value=20,
+            step=1,
+            label="Steps",
+            info="Number of denoising steps. More steps = higher quality but slower.",
+        )
+        guidance = gr.Slider(
+            1,
+            15,
+            value=7.5,
+            step=0.1,
+            label="Guidance",
+            info="Prompt adherence. Higher = closer to prompt, lower = more variety.",
+        )
+        weight = gr.Slider(
+            0.1,
+            2.0,
+            value=1.0,
+            step=0.1,
+            label="LoRA Weight",
+            info="Controls style intensity from the LoRA model. Lower = subtle, Higher = stronger.",
+        )
+    with gr.Row():
+        update_btn = gr.Button("Update Preset")
+        preview_btn = gr.Button("Preview Generation")
+    with gr.Row():
+        output_status = gr.Textbox(label="Update Status")
+    with gr.Row():
+        before_img = gr.Image(label="Before (current preset)")
+        after_img = gr.Image(label="After (with adjustments)")
+        preview_status = gr.Textbox(label="Preview Status")
+
+    update_btn.click(update_preset, inputs=[preset, steps, guidance, weight], outputs=output_status)
+    preview_btn.click(
+        preview_generation,
+        inputs=[prompt, preset, steps, guidance, weight],
+        outputs=[before_img, after_img, preview_status],
+    )
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PCS_PRESET_PORT", "7861"))
+    os.environ.setdefault("HF_HOME", os.path.join(PROJ, "hf_cache"))
+    os.environ["HF_HUB_DISABLE_SYMLINKS_WARNING"] = "1"
+    demo.launch(share=False, inbrowser=True, server_name="127.0.0.1", server_port=port, show_error=True)


### PR DESCRIPTION
## Summary
- add a dedicated Gradio interface for adjusting curated preset defaults and previewing results
- document the new preset tuning workflow in the README

## Testing
- python -m py_compile app/preset_tuner.py

------
https://chatgpt.com/codex/tasks/task_b_68d1de26177c832e95539c1898d3271e