### PR TITLE
Add media export helpers and tests

### DIFF
--- a/app/media_exports.py
+++ b/app/media_exports.py
@@ -1,0 +1,125 @@
+"""Helpers for exporting PixStu animation frames."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Iterable, List, Sequence, Tuple
+
+from PIL import Image
+
+__all__ = [
+    "OUTPUTS_DIR",
+    "apply_palette",
+    "extract_palette",
+    "nn_resize",
+    "save_gif",
+    "save_sprite_sheet",
+    "to_rgba",
+]
+
+
+OUTPUTS_DIR = os.environ.get(
+    "PCS_OUTPUTS_DIR",
+    os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "outputs")),
+)
+os.makedirs(OUTPUTS_DIR, exist_ok=True)
+
+
+def to_rgba(img: Image.Image) -> Image.Image:
+    """Return a copy of ``img`` in RGBA mode."""
+
+    return img.convert("RGBA") if img.mode != "RGBA" else img
+
+
+def nn_resize(img: Image.Image, size: Tuple[int, int]) -> Image.Image:
+    """Nearest-neighbour resize helper that preserves crisp edges."""
+
+    return img.resize(size, Image.NEAREST)
+
+
+def extract_palette(img: Image.Image, max_colors: int = 32) -> Image.Image:
+    """Return a palettized version of *img* suitable for palette donation."""
+
+    return img.convert("P", palette=Image.ADAPTIVE, colors=max_colors)
+
+
+def apply_palette(img: Image.Image, palette_donor: Image.Image) -> Image.Image:
+    """Quantize ``img`` using the palette from ``palette_donor``."""
+
+    quantized = img.convert("RGB").quantize(palette=palette_donor)
+    return quantized.convert("RGBA")
+
+
+def _ensure_rgba_frames(frames: Iterable[Image.Image]) -> List[Image.Image]:
+    return [to_rgba(frame) for frame in frames]
+
+
+def save_gif(
+    frames: Sequence[Image.Image],
+    duration_ms: int = 90,
+    loop: int = 0,
+    basename: str = "pixstu_anim",
+    lock_palette: bool = True,
+) -> str:
+    """Write ``frames`` to an animated GIF and return the output path."""
+
+    if not frames:
+        raise ValueError("No frames to save")
+
+    timestamp = int(time.time())
+    out_path = os.path.join(OUTPUTS_DIR, f"{basename}_{timestamp}.gif")
+
+    rgba_frames = _ensure_rgba_frames(frames)
+
+    if lock_palette:
+        palette = extract_palette(rgba_frames[0], max_colors=32)
+        palettized = [apply_palette(frame, palette) for frame in rgba_frames]
+    else:
+        palettized = [frame.convert("P", palette=Image.ADAPTIVE, colors=32) for frame in rgba_frames]
+
+    palettized[0].save(
+        out_path,
+        save_all=True,
+        append_images=palettized[1:],
+        duration=duration_ms,
+        loop=loop,
+        disposal=2,
+        transparency=0,
+        optimize=False,
+    )
+    return out_path
+
+
+def save_sprite_sheet(
+    frames: Sequence[Image.Image],
+    columns: int = 4,
+    padding: int = 0,
+    bgcolor: Tuple[int, int, int, int] = (0, 0, 0, 0),
+    basename: str = "pixstu_sheet",
+) -> str:
+    """Save ``frames`` to a sprite sheet PNG and return the output path."""
+
+    if not frames:
+        raise ValueError("No frames to save")
+
+    rgba_frames = _ensure_rgba_frames(frames)
+    width, height = rgba_frames[0].size
+    rows = (len(rgba_frames) + columns - 1) // columns
+
+    sheet_width = columns * width + padding * (columns - 1)
+    sheet_height = rows * height + padding * (rows - 1)
+    sheet = Image.new("RGBA", (sheet_width, sheet_height), bgcolor)
+
+    for index, frame in enumerate(rgba_frames):
+        row = index // columns
+        col = index % columns
+        x = col * (width + padding)
+        y = row * (height + padding)
+        sheet.paste(frame, (x, y), frame if frame.mode == "RGBA" else None)
+
+    timestamp = int(time.time())
+    out_path = os.path.join(OUTPUTS_DIR, f"{basename}_{timestamp}.png")
+    sheet.save(out_path)
+    return out_path
+

--- a/tests/test_media_exports.py
+++ b/tests/test_media_exports.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+import pytest
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _reload_module(tmp_path) -> "module":
+    os.environ["PCS_OUTPUTS_DIR"] = str(tmp_path)
+    module = importlib.import_module("app.media_exports")
+    return importlib.reload(module)
+
+
+def _solid_frames(count: int, size: int = 8) -> List[Image.Image]:
+    frames: List[Image.Image] = []
+    for idx in range(count):
+        color = (idx * 32 % 256, (255 - idx * 16) % 256, (idx * 64) % 256, 255)
+        frames.append(Image.new("RGBA", (size, size), color))
+    return frames
+
+def test_save_gif_creates_animation(tmp_path):
+    module = _reload_module(tmp_path)
+    frames = _solid_frames(3)
+
+    out_path = module.save_gif(frames, duration_ms=100, basename="test_anim")
+
+    assert os.path.isfile(out_path)
+    assert out_path.endswith(".gif")
+    assert os.path.commonpath([str(tmp_path), out_path]) == str(tmp_path)
+
+    with Image.open(out_path) as payload:
+        assert payload.is_animated
+        assert payload.n_frames == len(frames)
+        assert payload.info["duration"] == 100
+
+
+def test_save_sprite_sheet_layout(tmp_path):
+    module = _reload_module(tmp_path)
+    frames = _solid_frames(5, size=10)
+
+    out_path = module.save_sprite_sheet(frames, columns=3, padding=2, basename="test_sheet")
+
+    assert os.path.isfile(out_path)
+    assert out_path.endswith(".png")
+    assert os.path.commonpath([str(tmp_path), out_path]) == str(tmp_path)
+
+    with Image.open(out_path) as sheet:
+        # Expect two rows (3 columns -> 3 + 2 frames)
+        assert sheet.size == (3 * 10 + 2 * 2, 2 * 10 + 1 * 2)
+
+
+def test_save_functions_reject_empty_sequences(tmp_path):
+    module = _reload_module(tmp_path)
+
+    with pytest.raises(ValueError):
+        module.save_gif([], basename="empty")
+
+    with pytest.raises(ValueError):
+        module.save_sprite_sheet([], basename="empty")
+


### PR DESCRIPTION
## Summary
- add a reusable media_exports module with helpers for GIFs and sprite sheets
- ensure export helpers always work with RGBA frames and global palettes
- add pytest coverage for GIF and sprite sheet generation edge cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1e268dd8c832ea563244b22fd5613