### PR TITLE
Fix model path resolution for curated presets

### DIFF
--- a/app/curated_presets_ui.py
+++ b/app/curated_presets_ui.py
@@ -42,10 +42,22 @@ def _make_generator(seed: Optional[int]) -> Optional[torch.Generator]:
 def _resolve_under_models(path: Optional[str]) -> Optional[str]:
     if not path:
         return path
-    if os.path.isabs(path):
-        return path
-    candidate = os.path.join(MODELS_ROOT, path)
-    return os.path.abspath(candidate)
+
+    expanded = os.path.expanduser(str(path))
+    if os.path.isabs(expanded):
+        return os.path.normpath(expanded)
+
+    normalized = os.path.normpath(expanded)
+
+    project_candidate = os.path.abspath(os.path.join(PROJ, normalized))
+    if os.path.exists(project_candidate):
+        return project_candidate
+
+    parts = normalized.split(os.sep)
+    if parts and parts[0] == "models":
+        normalized = os.path.join(*parts[1:]) if len(parts) > 1 else ""
+
+    return os.path.abspath(os.path.join(MODELS_ROOT, normalized))
 
 
 def _resolve_model_id(candidate: Optional[str]) -> Optional[str]:

--- a/app/pixel_char_studio.py
+++ b/app/pixel_char_studio.py
@@ -32,8 +32,16 @@ MODELS_ROOT = os.getenv("PCS_MODELS_ROOT", os.path.join(EXE_DIR, "models"))
 
 def _abs_under_models(p):
     if not p: return p
-    if os.path.isabs(p): return os.path.normpath(p)
-    return os.path.normpath(os.path.abspath(os.path.join(MODELS_ROOT, p)))
+    expanded = os.path.expanduser(str(p))
+    if os.path.isabs(expanded): return os.path.normpath(expanded)
+    normalized = os.path.normpath(expanded)
+    project_candidate = os.path.abspath(os.path.join(PROJ, normalized))
+    if os.path.exists(project_candidate):
+        return os.path.normpath(project_candidate)
+    parts = normalized.split(os.sep)
+    if parts and parts[0] == "models":
+        normalized = os.path.join(*parts[1:]) if len(parts) > 1 else ""
+    return os.path.normpath(os.path.abspath(os.path.join(MODELS_ROOT, normalized)))
 
 def _device():
     if torch.cuda.is_available(): return "cuda", torch.float16, "cuda"

--- a/app/preset_tuner.py
+++ b/app/preset_tuner.py
@@ -17,9 +17,22 @@ PRESET_PATH = os.path.join(PROJ, "configs", "curated_models.json")
 def _abs_under_models(path: Optional[str]) -> Optional[str]:
     if not path:
         return path
-    if os.path.isabs(path):
-        return os.path.normpath(path)
-    return os.path.normpath(os.path.abspath(os.path.join(MODELS_ROOT, path)))
+
+    expanded = os.path.expanduser(str(path))
+    if os.path.isabs(expanded):
+        return os.path.normpath(expanded)
+
+    normalized = os.path.normpath(expanded)
+
+    project_candidate = os.path.abspath(os.path.join(PROJ, normalized))
+    if os.path.exists(project_candidate):
+        return os.path.normpath(project_candidate)
+
+    parts = normalized.split(os.sep)
+    if parts and parts[0] == "models":
+        normalized = os.path.join(*parts[1:]) if len(parts) > 1 else ""
+
+    return os.path.normpath(os.path.abspath(os.path.join(MODELS_ROOT, normalized)))
 
 
 def _device() -> Tuple[str, torch.dtype]:


### PR DESCRIPTION
## Summary
- normalize preset model paths so entries like `models/...` resolve correctly against the project directory
- fall back to the models root after stripping a leading `models/` directory segment and expanding user paths
- apply the same logic to the studio UI, preset tuner, and curated preset loader helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1e26faaac832eafd509f8c6b171a3