### PR TITLE
Add GIF utilities and tests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""PixStu application helpers."""

--- a/app/gif_tools.py
+++ b/app/gif_tools.py
@@ -1,0 +1,94 @@
+"""Utilities for saving animation previews produced by PixStu."""
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from typing import Sequence, Tuple
+
+from PIL import Image
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
+PROJ = os.path.abspath(os.path.join(ROOT, ".."))
+OUTPUTS_DIR = os.environ.get("PCS_OUTPUTS_DIR", os.path.join(PROJ, "outputs"))
+os.makedirs(OUTPUTS_DIR, exist_ok=True)
+
+
+def _normalize_frames(frames: Sequence[Image.Image]) -> Tuple[int, int, Sequence[Image.Image]]:
+    if not frames:
+        raise ValueError("at least one frame is required")
+
+    base_w, base_h = frames[0].size
+    normalized = []
+    for frame in frames:
+        if frame.size != (base_w, base_h):
+            normalized.append(nn_resize(frame, (base_w, base_h)))
+        else:
+            normalized.append(frame)
+    return base_w, base_h, normalized
+
+
+def nn_resize(img: Image.Image, size: Tuple[int, int]) -> Image.Image:
+    """Resize ``img`` using nearest-neighbor sampling."""
+
+    if img.size == size:
+        return img.copy()
+    return img.resize(size, Image.NEAREST)
+
+
+def _unique_path(suffix: str) -> str:
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    ident = uuid.uuid4().hex[:8]
+    filename = f"pcs-{stamp}-{ident}.{suffix}"
+    return os.path.join(OUTPUTS_DIR, filename)
+
+
+def save_gif(frames: Sequence[Image.Image], *, duration_ms: int = 120, loop: int = 0) -> str:
+    """Save ``frames`` as an animated GIF in the configured outputs directory."""
+
+    base_w, base_h, normalized = _normalize_frames(frames)
+    path = _unique_path("gif")
+    normalized[0].save(
+        path,
+        save_all=True,
+        append_images=list(normalized[1:]),
+        duration=duration_ms,
+        loop=loop,
+        disposal=2,
+    )
+    return path
+
+
+def save_sprite_sheet(
+    frames: Sequence[Image.Image],
+    *,
+    columns: int = 4,
+    padding: int = 0,
+    background: Tuple[int, int, int, int] | Tuple[int, int, int] = (0, 0, 0, 0),
+) -> str:
+    """Arrange ``frames`` into a sprite sheet image saved to disk."""
+
+    if columns <= 0:
+        raise ValueError("columns must be positive")
+
+    base_w, base_h, normalized = _normalize_frames(frames)
+    columns = max(1, columns)
+    rows = (len(normalized) + columns - 1) // columns
+
+    sheet_w = columns * base_w + padding * (columns - 1)
+    sheet_h = rows * base_h + padding * (rows - 1)
+    mode = "RGBA" if len(background) == 4 else "RGB"
+    sheet = Image.new(mode, (sheet_w, sheet_h), background)
+
+    for idx, frame in enumerate(normalized):
+        col = idx % columns
+        row = idx // columns
+        x = col * (base_w + padding)
+        y = row * (base_h + padding)
+        if frame.mode != mode:
+            frame = frame.convert(mode)
+        sheet.paste(frame, (x, y))
+
+    path = _unique_path("png")
+    sheet.save(path)
+    return path

--- a/tests/test_gif_tools.py
+++ b/tests/test_gif_tools.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PIL import Image
+
+from app.gif_tools import save_gif, save_sprite_sheet, nn_resize
+
+
+def test_nn_resize_crisp():
+    img = Image.new("RGBA", (16, 16), (255, 0, 0, 255))
+    up = nn_resize(img, (32, 32))
+    assert up.size == (32, 32)
+
+
+def test_save_gif(tmp_path, monkeypatch):
+    monkeypatch.setenv("PCS_OUTPUTS_DIR", str(tmp_path))
+    from importlib import reload
+    import app.gif_tools as gif_tools
+    reload(gif_tools)
+
+    frames = [Image.new("RGBA", (16, 16), (i * 10 % 255, 0, 0, 255)) for i in range(4)]
+    out = gif_tools.save_gif(frames, duration_ms=80)
+    assert out.endswith(".gif")
+    assert os.path.exists(out)
+
+
+def test_save_sprite_sheet(tmp_path, monkeypatch):
+    monkeypatch.setenv("PCS_OUTPUTS_DIR", str(tmp_path))
+    from importlib import reload
+    import app.gif_tools as gif_tools
+    reload(gif_tools)
+
+    frames = [Image.new("RGBA", (16, 16), (0, i * 10 % 255, 0, 255)) for i in range(6)]
+    out = gif_tools.save_sprite_sheet(frames, columns=3, padding=1)
+    assert out.endswith(".png")
+    assert os.path.exists(out)


### PR DESCRIPTION
## Summary
- add an app.gif_tools module that handles nearest-neighbor resizing and exports GIFs and sprite sheets into the outputs folder
- mark app as a package so the new utilities can be imported and reused
- cover the utilities with pytest cases validating resizing, GIF export, and sprite sheet export

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1e27de908832eb80bec8fe7b97f8e