### PR TITLE
Add masking utilities and tests

### DIFF
--- a/app/masking.py
+++ b/app/masking.py
@@ -1,0 +1,81 @@
+"""Utilities for masking out background colors from images."""
+
+from typing import Tuple
+
+from PIL import Image
+
+
+RGBColor = Tuple[int, int, int]
+
+
+def _ensure_rgb(image: Image.Image) -> Image.Image:
+    """Return a copy of *image* converted to RGB."""
+
+    if image.mode == "RGB":
+        return image
+    return image.convert("RGB")
+
+
+def estimate_bg_color(image: Image.Image) -> RGBColor:
+    """Estimate the background color of *image*.
+
+    The estimation samples the outer border pixels and returns their average
+    color.  This works well for the simple solid background images used in the
+    tests.
+    """
+
+    rgb_image = _ensure_rgb(image)
+    width, height = rgb_image.size
+    if width == 0 or height == 0:
+        raise ValueError("Image must have non-zero dimensions")
+
+    border_pixels: list[RGBColor] = []
+    pixels = rgb_image.load()
+
+    for x in range(width):
+        border_pixels.append(pixels[x, 0])
+        if height > 1:
+            border_pixels.append(pixels[x, height - 1])
+
+    for y in range(1, height - 1):
+        border_pixels.append(pixels[0, y])
+        if width > 1:
+            border_pixels.append(pixels[width - 1, y])
+
+    r_total = sum(pixel[0] for pixel in border_pixels)
+    g_total = sum(pixel[1] for pixel in border_pixels)
+    b_total = sum(pixel[2] for pixel in border_pixels)
+    count = len(border_pixels)
+    return (
+        int(round(r_total / count)),
+        int(round(g_total / count)),
+        int(round(b_total / count)),
+    )
+
+
+def _color_distance(c1: RGBColor, c2: RGBColor) -> int:
+    return max(abs(a - b) for a, b in zip(c1, c2))
+
+
+def make_alpha(image: Image.Image, bg_color: RGBColor, *, tol: int = 0) -> Image.Image:
+    """Return a copy of *image* with the background made transparent.
+
+    Pixels whose color is within ``tol`` of ``bg_color`` (using the maximum
+    per-channel difference) have their alpha channel set to zero.
+    """
+
+    if tol < 0:
+        raise ValueError("tol must be non-negative")
+
+    rgba_image = image.convert("RGBA")
+    width, height = rgba_image.size
+    pixels = rgba_image.load()
+
+    for y in range(height):
+        for x in range(width):
+            r, g, b, a = pixels[x, y]
+            if _color_distance((r, g, b), bg_color) <= tol:
+                pixels[x, y] = (r, g, b, 0)
+
+    return rgba_image
+

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,0 +1,16 @@
+from PIL import Image
+
+from app.masking import estimate_bg_color, make_alpha
+
+
+def test_estimate_bg_color_simple():
+    img = Image.new("RGB", (10, 10), (10, 20, 30))
+    assert estimate_bg_color(img) == (10, 20, 30)
+
+
+def test_make_alpha_tolerance():
+    img = Image.new("RGB", (4, 4), (0, 255, 0))
+    img.putpixel((1, 1), (0, 250, 0))  # close to bg
+    out = make_alpha(img, (0, 255, 0), tol=10)
+    assert out.getpixel((1, 1))[3] == 0  # transparent pixel
+


### PR DESCRIPTION
## Summary
- add an `app.masking` module with utilities for estimating background color and masking backgrounds with transparency
- create tests for the new masking functions to ensure correct behavior with uniform backgrounds and tolerance-based masking

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1e75c1110832e9043a9266d1a7b4f