### PR TITLE
Add media masking utilities and tests

### DIFF
--- a/app/media_masking.py
+++ b/app/media_masking.py
@@ -1,0 +1,132 @@
+"""Background masking utilities for GIFs and videos."""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+from typing import List, Tuple
+
+from PIL import Image, ImageSequence
+
+from .media_exports import save_gif
+
+OUTPUTS_DIR = os.environ.get(
+    "PCS_OUTPUTS_DIR",
+    os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "outputs")),
+)
+os.makedirs(OUTPUTS_DIR, exist_ok=True)
+
+
+def _rgb(img: Image.Image) -> Image.Image:
+    """Return ``img`` converted to RGB if necessary."""
+
+    return img.convert("RGB") if img.mode != "RGB" else img
+
+
+def estimate_bg_color(img: Image.Image) -> Tuple[int, int, int]:
+    """Estimate the dominant background color of ``img``.
+
+    The four corners are sampled and their mode returned. If there is no
+    majority color the average of the samples is used instead.
+    """
+
+    rgb = _rgb(img)
+    width, height = rgb.size
+    samples = [
+        rgb.getpixel((0, 0)),
+        rgb.getpixel((width - 1, 0)),
+        rgb.getpixel((0, height - 1)),
+        rgb.getpixel((width - 1, height - 1)),
+    ]
+
+    counts: dict[Tuple[int, int, int], int] = {}
+    for color in samples:
+        counts[color] = counts.get(color, 0) + 1
+
+    mode = max(counts.items(), key=lambda kv: kv[1])[0]
+    if counts[mode] >= 2:
+        return mode
+
+    r = sum(color[0] for color in samples) // 4
+    g = sum(color[1] for color in samples) // 4
+    b = sum(color[2] for color in samples) // 4
+    return (r, g, b)
+
+
+def _dist(c1: Tuple[int, int, int], c2: Tuple[int, int, int]) -> float:
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(c1, c2)))
+
+
+def make_alpha(img: Image.Image, bg: Tuple[int, int, int], tol: int = 20) -> Image.Image:
+    """Return an RGBA image with background pixels made transparent."""
+
+    rgba = img.convert("RGBA")
+    pixels = rgba.load()
+    width, height = rgba.size
+    for y in range(height):
+        for x in range(width):
+            r, g, b, a = pixels[x, y]
+            if _dist((r, g, b), bg) <= tol:
+                pixels[x, y] = (r, g, b, 0)
+    return rgba
+
+
+def mask_gif(input_path: str, tolerance: int = 20, lock_palette: bool = True) -> str:
+    """Apply background masking to a GIF file and return the output path."""
+
+    with Image.open(input_path) as payload:
+        info = dict(payload.info)
+        bg = estimate_bg_color(payload.convert("RGB"))
+        frames: List[Image.Image] = []
+        for frame in ImageSequence.Iterator(payload):
+            rgba = make_alpha(frame.convert("RGBA"), bg, tol=int(tolerance))
+            frames.append(rgba)
+
+    out_path = save_gif(
+        frames,
+        duration_ms=info.get("duration", 90),
+        loop=info.get("loop", 0),
+        lock_palette=lock_palette,
+    )
+    return out_path
+
+
+def mask_video_to_outputs(
+    input_path: str,
+    tolerance: int = 20,
+    target_size: Tuple[int, int] | None = None,
+    export_gif: bool = True,
+    export_png_seq: bool = True,
+    bg_override: Tuple[int, int, int] | None = None,
+) -> Tuple[str | None, str | None]:
+    """Mask frames from ``input_path`` and export as GIF and/or PNG sequence."""
+
+    import imageio.v3 as iio
+
+    frames: List[Image.Image] = []
+    bg: Tuple[int, int, int] | None = None
+
+    for index, frame in enumerate(iio.imiter(input_path)):
+        img = Image.fromarray(frame)
+        if target_size:
+            img = img.resize(target_size, Image.NEAREST)
+        if index == 0:
+            bg = bg_override or estimate_bg_color(img)
+        assert bg is not None
+        frames.append(make_alpha(img, bg, tol=int(tolerance)))
+
+    gif_path: str | None = None
+    png_dir: str | None = None
+
+    if export_gif and frames:
+        gif_path = save_gif(frames, duration_ms=90, loop=0, lock_palette=True)
+
+    if export_png_seq and frames:
+        timestamp = int(time.time())
+        png_dir = os.path.join(OUTPUTS_DIR, f"masked_seq_{timestamp}")
+        os.makedirs(png_dir, exist_ok=True)
+        for idx, frame in enumerate(frames):
+            frame.save(os.path.join(png_dir, f"frame_{idx:04d}.png"))
+
+    return gif_path, png_dir

--- a/tests/test_media_masking.py
+++ b/tests/test_media_masking.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _reload_module(tmp_path) -> "module":
+    os.environ["PCS_OUTPUTS_DIR"] = str(tmp_path)
+    media_exports = importlib.import_module("app.media_exports")
+    importlib.reload(media_exports)
+    module = importlib.import_module("app.media_masking")
+    return importlib.reload(module)
+
+
+def _make_test_gif(path: Path, frames: list[Image.Image]) -> None:
+    frames[0].save(path, save_all=True, append_images=frames[1:], duration=100, loop=0)
+
+
+def test_estimate_bg_color_mode(tmp_path):
+    module = _reload_module(tmp_path)
+    img = Image.new("RGB", (4, 4), (0, 0, 0))
+    img.putpixel((3, 0), (255, 0, 0))
+    img.putpixel((0, 3), (255, 0, 0))
+
+    assert module.estimate_bg_color(img) == (0, 0, 0)
+
+
+def test_estimate_bg_color_average(tmp_path):
+    module = _reload_module(tmp_path)
+    img = Image.new("RGB", (2, 2))
+    img.putpixel((0, 0), (0, 0, 0))
+    img.putpixel((1, 0), (20, 20, 20))
+    img.putpixel((0, 1), (40, 40, 40))
+    img.putpixel((1, 1), (60, 60, 60))
+
+    assert module.estimate_bg_color(img) == (30, 30, 30)
+
+
+def test_make_alpha_transparency(tmp_path):
+    module = _reload_module(tmp_path)
+    img = Image.new("RGBA", (2, 1))
+    img.putpixel((0, 0), (10, 10, 10, 255))
+    img.putpixel((1, 0), (50, 50, 50, 255))
+
+    result = module.make_alpha(img, (10, 10, 10), tol=0)
+    assert result.getpixel((0, 0))[3] == 0
+    assert result.getpixel((1, 0))[3] == 255
+
+
+def test_mask_gif_creates_transparent_output(tmp_path):
+    module = _reload_module(tmp_path)
+    frames = [
+        Image.new("RGBA", (4, 4), (255, 0, 0, 255)),
+        Image.new("RGBA", (4, 4), (255, 0, 0, 255)),
+    ]
+    for frame in frames:
+        frame.putpixel((1, 1), (0, 0, 255, 255))
+
+    src = tmp_path / "input.gif"
+    _make_test_gif(src, frames)
+
+    out_path = module.mask_gif(str(src), tolerance=0, lock_palette=False)
+    assert os.path.isfile(out_path)
+
+    with Image.open(out_path) as result:
+        first = result.convert("RGBA")
+        assert first.getpixel((0, 0))[3] == 0
+        assert first.getpixel((1, 1))[3] == 255
+
+
+def test_mask_video_to_outputs_exports(tmp_path):
+    module = _reload_module(tmp_path)
+    frames = [Image.new("RGBA", (3, 3), (0, 255, 0, 255)) for _ in range(2)]
+    for frame in frames:
+        frame.putpixel((1, 1), (255, 0, 0, 255))
+
+    src = tmp_path / "input.gif"
+    _make_test_gif(src, frames)
+
+    gif_path, png_dir = module.mask_video_to_outputs(
+        str(src),
+        tolerance=0,
+        target_size=(2, 2),
+        export_gif=True,
+        export_png_seq=True,
+    )
+
+    assert gif_path is not None and os.path.isfile(gif_path)
+    assert png_dir is not None and os.path.isdir(png_dir)
+
+    png_path = Path(png_dir)
+    png_files = sorted(png_path.glob("*.png"))
+    assert png_files, "expected at least one exported frame"
+
+    with Image.open(png_files[0]) as png:
+        assert png.size == (2, 2)
+        assert png.getpixel((0, 0))[3] == 0
+


### PR DESCRIPTION
## Summary
- add a `media_masking` helper module that can estimate background colors, build transparency masks, and export masked GIFs/videos
- write regression tests that cover background estimation, alpha masking, and export flows for GIF and video inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1e7418144832e8fd67402fa4af1f1