### PR TITLE
Align masking heuristics across modules

### DIFF
--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -8,6 +8,17 @@ def test_estimate_bg_color_simple():
     assert estimate_bg_color(img) == (10, 20, 30)
 
 
+def test_estimate_bg_color_corner_average():
+    img = Image.new("RGB", (2, 2))
+    img.putpixel((0, 0), (0, 0, 0))
+    img.putpixel((1, 0), (40, 40, 40))
+    img.putpixel((0, 1), (80, 80, 80))
+    img.putpixel((1, 1), (120, 120, 120))
+
+    # All corners are unique so the average should be returned.
+    assert estimate_bg_color(img) == (60, 60, 60)
+
+
 def test_make_alpha_tolerance():
     img = Image.new("RGB", (4, 4), (0, 255, 0))
     img.putpixel((1, 1), (0, 250, 0))  # close to bg


### PR DESCRIPTION
## Summary
- align the masking helper with the media modules so corner sampling and tolerance handling behave the same everywhere
- add a regression test to ensure images with unique corner colours produce the averaged background

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1ebb3a680832e84e3796da195633f