### PR TITLE
Add helper to write exported frames

### DIFF
--- a/app/media_exports.py
+++ b/app/media_exports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 import os
 import time
@@ -20,6 +21,7 @@ __all__ = [
     "nn_resize",
     "save_gif",
     "save_sprite_sheet",
+    "write_frames",
     "to_rgba",
 ]
 
@@ -109,6 +111,40 @@ def make_alpha(img: Image.Image, bg: Tuple[int, int, int], tol: int = 20) -> Ima
 
 def _ensure_rgba_frames(frames: Iterable[Image.Image]) -> List[Image.Image]:
     return [to_rgba(frame) for frame in frames]
+
+
+def write_frames(
+    frames: Sequence[Image.Image],
+    session_dir: str | None = None,
+    prefix: str = "frame",
+) -> str:
+    """Write ``frames`` to ``session_dir`` and return the directory path.
+
+    A ``frames.json`` manifest is written alongside the PNG files so that
+    the front-end can locate the generated frames.  When ``session_dir`` is
+    omitted a timestamped directory inside :data:`OUTPUTS_DIR` is created.
+    """
+
+    timestamp = int(time.time())
+
+    if session_dir is None:
+        session_dir = os.path.join(OUTPUTS_DIR, f"session_{timestamp}")
+
+    frames_dir = os.path.join(session_dir, "frames")
+    os.makedirs(frames_dir, exist_ok=True)
+
+    manifest: List[str] = []
+    for index, frame in enumerate(frames):
+        file_path = os.path.join(frames_dir, f"{prefix}_{index:04d}.png")
+        frame.save(file_path)
+        manifest.append(os.path.basename(file_path))
+
+    manifest_path = os.path.join(frames_dir, "frames.json")
+    payload = {"frames": manifest, "timestamp": timestamp}
+    with open(manifest_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+
+    return frames_dir
 
 
 def save_gif(

--- a/tests/test_media_exports.py
+++ b/tests/test_media_exports.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
 from pathlib import Path
@@ -66,4 +67,34 @@ def test_save_functions_reject_empty_sequences(tmp_path):
 
     with pytest.raises(ValueError):
         module.save_sprite_sheet([], basename="empty")
+
+
+def test_write_frames_generates_manifest(tmp_path):
+    module = _reload_module(tmp_path)
+    frames = _solid_frames(3)
+
+    out_dir = Path(module.write_frames(frames, prefix="snap"))
+
+    assert out_dir.exists() and out_dir.is_dir()
+    assert out_dir.parent.parent == tmp_path
+
+    manifest_path = out_dir / "frames.json"
+    assert manifest_path.is_file()
+
+    data = json.loads(manifest_path.read_text())
+    assert isinstance(data["timestamp"], int)
+    assert data["frames"] == [f"snap_{idx:04d}.png" for idx in range(len(frames))]
+
+    for name in data["frames"]:
+        assert (out_dir / name).is_file()
+
+
+def test_write_frames_respects_custom_session_dir(tmp_path):
+    module = _reload_module(tmp_path)
+    frames = _solid_frames(2)
+
+    session_dir = tmp_path / "custom_session"
+    frames_dir = module.write_frames(frames, session_dir=str(session_dir), prefix="frame")
+
+    assert Path(frames_dir).parent == session_dir
 


### PR DESCRIPTION
## Summary
- add a write_frames helper to media_exports that writes PNG frames and a manifest
- extend media_exports tests to cover the new helper and validate manifest contents

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1ef7b186c832e817556fe8cba01be