### PR TITLE
Add refresh button to timeline preview tab

### DIFF
--- a/app/pixel_char_studio.py
+++ b/app/pixel_char_studio.py
@@ -247,6 +247,7 @@ with gr.Blocks(analytics_enabled=False) as demo:
             meta = gr.Code(label="Meta", language="json")
         with gr.Tab("Timeline Preview"):
             gr.Markdown("#### Scrub through frames with onion-skinning and FPS control")
+            refresh_btn = gr.Button("Refresh Preview", variant="secondary")
             with gr.Row():
                 timeline_html = gr.HTML("""
                 <div id='px-timeline' style='display:flex;gap:12px;align-items:center'>
@@ -297,6 +298,7 @@ with gr.Blocks(analytics_enabled=False) as demo:
                 })();
                 </script>
                 """)
+            refresh_btn.click(fn=None, inputs=None, outputs=None, _js="() => { location.reload(); }")
     status = gr.Textbox(label="Status")
 
     def _on_gen(prompt,negative,steps,cfg,width,height,quality,pixel_scale,palette,dither,crisp,sharpen,base_model,lcm_dir,lora_files,lw_json):


### PR DESCRIPTION
## Summary
- add a secondary "Refresh Preview" button inside the Timeline Preview tab
- hook the button to a client-side reload using Gradio's `_js` callback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d1ef8e6c64832eb90a7dbbb00b0919