### PR TITLE
Validate sprite sheet layout arguments

### DIFF
--- a/app/media_exports.py
+++ b/app/media_exports.py
@@ -159,6 +159,12 @@ def save_sprite_sheet(
     if not frames:
         raise ValueError("No frames to save")
 
+    if columns <= 0:
+        raise ValueError("columns must be a positive integer")
+
+    if padding < 0:
+        raise ValueError("padding cannot be negative")
+
     rgba_frames = _ensure_rgba_frames(frames)
     width, height = rgba_frames[0].size
     rows = (len(rgba_frames) + columns - 1) // columns


### PR DESCRIPTION
## Summary
- prevent sprite sheet generation with zero or negative columns
- reject negative padding values before composing the sheet image

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1f006ee3c832e9ac58d0a75d3adaf