### PR TITLE
Preserve alpha when applying locked palettes

### DIFF
--- a/app/media_exports.py
+++ b/app/media_exports.py
@@ -62,8 +62,12 @@ def extract_palette(img: Image.Image, max_colors: int = 32) -> Image.Image:
 def apply_palette(img: Image.Image, palette_donor: Image.Image) -> Image.Image:
     """Quantize ``img`` using the palette from ``palette_donor``."""
 
-    quantized = img.convert("RGB").quantize(palette=palette_donor)
-    return quantized.convert("RGBA")
+    rgba = img.convert("RGBA")
+    alpha = rgba.getchannel("A")
+    quantized = rgba.convert("RGB").quantize(palette=palette_donor)
+    palettized = quantized.convert("RGBA")
+    palettized.putalpha(alpha)
+    return palettized
 
 
 def _rgb(img: Image.Image) -> Image.Image:

--- a/tests/test_media_exports.py
+++ b/tests/test_media_exports.py
@@ -69,6 +69,19 @@ def test_save_functions_reject_empty_sequences(tmp_path):
         module.save_sprite_sheet([], basename="empty")
 
 
+def test_apply_palette_preserves_alpha(tmp_path):
+    module = _reload_module(tmp_path)
+
+    donor = module.extract_palette(Image.new("RGBA", (2, 2), (255, 0, 0, 255)))
+    src = Image.new("RGBA", (2, 2), (0, 0, 255, 0))
+    src.putpixel((1, 1), (0, 255, 0, 200))
+
+    palettized = module.apply_palette(src, donor)
+
+    assert palettized.getpixel((0, 0))[3] == 0
+    assert palettized.getpixel((1, 1))[3] == 200
+
+
 def test_write_frames_generates_manifest(tmp_path):
     module = _reload_module(tmp_path)
     frames = _solid_frames(3)


### PR DESCRIPTION
## Summary
- ensure applying a donated palette keeps the original alpha channel intact
- add regression coverage confirming palette application preserves transparency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1f5b147c8832e8fd7d98b9fa7cd73