### PR TITLE
Add preview frame exports to GIF creator

### DIFF
--- a/app/gif_creator.py
+++ b/app/gif_creator.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional, Sequence, Tuple
 
 from PIL import Image, ImageOps
 
-from . import pipeline_cache
+from . import media_exports, pipeline_cache
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 PROJ = os.path.abspath(os.path.join(ROOT, ".."))
@@ -69,8 +69,9 @@ def make_gif_from_sprite(
     img_strength: float,
     lock_palette: bool,
     export_sheet: bool,
-) -> Tuple[str, Optional[str]]:
-    """Create an animated GIF and optional sprite sheet from a single sprite.
+    export_preview: bool = False,
+) -> Tuple[str, Optional[str], Optional[str]]:
+    """Create an animated GIF and optional preview exports from a sprite.
 
     The implementation is intentionally lightweight: it currently reuses the
     uploaded sprite for every frame while applying basic resizing so that the
@@ -117,4 +118,8 @@ def make_gif_from_sprite(
         sheet_path = os.path.join(OUTPUTS_DIR, sheet_filename)
         sheet.save(sheet_path)
 
-    return gif_path, sheet_path
+    preview_dir: Optional[str] = None
+    if export_preview:
+        preview_dir = media_exports.write_frames(frame_sequence)
+
+    return gif_path, sheet_path, preview_dir

--- a/tests/test_gif_creator.py
+++ b/tests/test_gif_creator.py
@@ -1,0 +1,59 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PIL import Image
+
+
+def _reload_gif_creator():
+    from importlib import reload
+
+    import app.media_exports as media_exports
+    import app.gif_creator as gif_creator
+
+    reload(media_exports)
+    return reload(gif_creator)
+
+
+@pytest.fixture
+def gif_creator(monkeypatch, tmp_path):
+    monkeypatch.setenv("PCS_OUTPUTS_DIR", str(tmp_path))
+    return _reload_gif_creator()
+
+
+def test_make_gif_from_sprite_can_export_preview(gif_creator, tmp_path):
+    sprite_path = tmp_path / "sprite.png"
+    Image.new("RGBA", (8, 8), (255, 0, 0, 255)).save(sprite_path)
+
+    gif_path, sheet_path, preview_dir = gif_creator.make_gif_from_sprite(
+        sprite_path=str(sprite_path),
+        preset_name="default",
+        prompt=None,
+        frames=3,
+        frame_size=8,
+        duration_ms=50,
+        seed=None,
+        seed_jitter=0,
+        motion_mode="none",
+        img_strength=1.0,
+        lock_palette=False,
+        export_sheet=False,
+        export_preview=True,
+    )
+
+    assert gif_path.endswith(".gif")
+    assert sheet_path is None
+    assert preview_dir is not None
+
+    manifest_path = Path(preview_dir) / "frames.json"
+    assert manifest_path.exists()
+
+    payload = json.loads(manifest_path.read_text("utf-8"))
+    assert payload["frames"]
+    for filename in payload["frames"]:
+        frame_path = Path(preview_dir) / filename
+        assert frame_path.exists()


### PR DESCRIPTION
## Summary
- add an optional `export_preview` toggle to the GIF creator so the UI can request timeline frames
- reuse `media_exports.write_frames` to create PNG previews and return the frames directory alongside the GIF path
- cover the new behaviour with a regression test that confirms the frames manifest is written

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d200bf2a74832eb7dfe7453c658024