### PR TITLE
Handle curated preset files saved with BOM

### DIFF
--- a/app/pixel_char_studio.py
+++ b/app/pixel_char_studio.py
@@ -117,7 +117,11 @@ def scan_loras():
 
 def load_curated():
     try:
-        with open(os.path.join(PROJ,"configs","curated_models.json"),"r",encoding="utf-8") as f:
+        with open(
+            os.path.join(PROJ, "configs", "curated_models.json"),
+            "r",
+            encoding="utf-8-sig",
+        ) as f:
             presets = json.load(f).get("presets") or []
             LOGGER.debug("Loaded %d curated presets", len(presets))
             return presets

--- a/app/preset_tuner.py
+++ b/app/preset_tuner.py
@@ -50,7 +50,7 @@ DEV, DTYPE = _device()
 def _load_presets() -> List[dict]:
     if not os.path.isfile(PRESET_PATH):
         return []
-    with open(PRESET_PATH, "r", encoding="utf-8") as fh:
+    with open(PRESET_PATH, "r", encoding="utf-8-sig") as fh:
         payload = json.load(fh)
     return payload.get("presets", [])
 


### PR DESCRIPTION
## Summary
- allow both the main app and preset tuner to read curated preset JSON files saved with a UTF-8 BOM
- leave writes as UTF-8 so future saves remain clean

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d208aca6c8832eb515b822e2e0f4b1