### PR TITLE
Automate Wan2.2 installation

### DIFF
--- a/chargen/studio.py
+++ b/chargen/studio.py
@@ -1,6 +1,4 @@
 import os
-import subprocess
-import sys
 from typing import Iterable, List
 
 import gradio as gr
@@ -17,6 +15,7 @@ from chargen.img2gif import img2gif
 from chargen.txt2vid import txt2vid
 from chargen.txt2vid_diffusers import txt2vid_diffusers
 from chargen.txt2vid_wan import txt2vid_wan_guarded
+from chargen.wan_install import ensure_wan22_installed
 
 RETRO_CSS = ":root { --accent: #44e0ff; } body { font-family: 'Press Start 2P', monospace; background: #0a0a0f; color: #e6e6f0; } .gr-button{border-radius:16px;}"
 
@@ -196,32 +195,8 @@ def _hf_auth(token: str) -> str:
 
 
 def _install_wan22() -> str:
-    try:
-        __import__("wan22")
-    except ModuleNotFoundError:
-        command = [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "git+https://github.com/Wan-Video/Wan2.2.git#egg=wan22",
-        ]
-        try:
-            result = subprocess.run(
-                command,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:  # pragma: no cover - runtime failures
-            output = exc.stderr.strip() or exc.stdout.strip() or str(exc)
-            return f"Wan2.2 install failed: {output}"
-        output = result.stdout.strip().splitlines()
-        tail = output[-1] if output else "Installation complete."
-        return f"Wan2.2 installed: {tail}"
-    except Exception as exc:  # pragma: no cover - runtime failures
-        return f"Wan2.2 check failed: {exc}"
-    return "Wan2.2 already installed."
+    _, message, _ = ensure_wan22_installed()
+    return f"Wan2.2 {message}"
 
 
 def _quick_render(preset_name, lora_path, weight):

--- a/chargen/wan_install.py
+++ b/chargen/wan_install.py
@@ -1,0 +1,58 @@
+"""Utilities for installing the optional Wan2.2 dependency."""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from typing import Tuple
+
+WAN_MODULE = "wan22"
+WAN_SPEC = "git+https://github.com/Wan-Video/Wan2.2.git#egg=wan22"
+
+
+def ensure_wan22_installed() -> Tuple[bool, str, bool]:
+    """Ensure the Wan2.2 package is available.
+
+    Returns a tuple of ``(available, message, installed_now)`` where:
+    - ``available`` indicates whether the module can be imported after running.
+    - ``message`` contains a human-readable status message without the ``Wan2.2`` prefix.
+    - ``installed_now`` is ``True`` when the package was installed during this call.
+    """
+
+    try:
+        importlib.import_module(WAN_MODULE)
+    except ModuleNotFoundError:
+        command = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            WAN_SPEC,
+        ]
+        try:
+            result = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            output = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+            return False, f"install failed: {output}", False
+        except Exception as exc:  # pragma: no cover - runtime failures
+            return False, f"install failed: {exc}", False
+        importlib.invalidate_caches()
+        try:
+            importlib.import_module(WAN_MODULE)
+        except Exception as exc:  # pragma: no cover - runtime failures
+            return False, f"installed but import failed: {exc}", True
+        output = result.stdout.strip().splitlines()
+        tail = output[-1] if output else "Installation complete."
+        return True, f"installed: {tail}", True
+    except Exception as exc:  # pragma: no cover - runtime failures
+        return False, f"check failed: {exc}", False
+    return True, "already installed.", False
+
+
+__all__ = ["ensure_wan22_installed"]


### PR DESCRIPTION
## Summary
- add a shared Wan2.2 installer helper that ensures the optional dependency is importable
- reuse the helper from the UI installer button so messaging stays consistent
- trigger the installer automatically from the Wan guarded generator and surface install status notes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d419d0f718832e938702e007c99bac