### PR TITLE
Improve Wan2.2 install failure diagnostics

### DIFF
--- a/chargen/wan_install.py
+++ b/chargen/wan_install.py
@@ -5,10 +5,59 @@ from __future__ import annotations
 import importlib
 import subprocess
 import sys
-from typing import Tuple
+from typing import Iterable, Tuple
 
 WAN_MODULE = "wan22"
 WAN_SPEC = "git+https://github.com/Wan-Video/Wan2.2.git#egg=wan22"
+
+
+def _normalise_lines(output: str) -> Iterable[str]:
+    """Yield trimmed, non-empty lines from the provided ``output`` string."""
+
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped:
+            yield stripped
+
+
+def _summarise_install_failure(output: str) -> str:
+    """Return a concise, user-focused explanation for a pip install failure."""
+
+    lines = list(_normalise_lines(output))
+    if not lines:
+        return "install failed but pip produced no output."
+
+    lowered = [line.lower() for line in lines]
+
+    for line, lower in zip(lines, lowered):
+        if "fatal: unable to access" in lower:
+            if "403" in lower or "forbidden" in lower:
+                return (
+                    "GitHub denied access to the Wan2.2 repository (HTTP 403). "
+                    "Check your proxy or network permissions."
+                )
+            if "could not resolve host" in lower:
+                return (
+                    "GitHub hostname could not be resolved while downloading Wan2.2. "
+                    "Check your internet connection or DNS configuration."
+                )
+            if "connection timed out" in lower:
+                return (
+                    "Connection to GitHub timed out while downloading Wan2.2. "
+                    "Verify your network stability."
+                )
+            return line
+
+        if "git" in lower and ("not found" in lower or "not recognized" in lower):
+            return "Git does not appear to be installed. Install Git and retry."
+
+        if "ssl" in lower and "certificate" in lower:
+            return (
+                "SSL verification failed when contacting GitHub. Check your certificate "
+                "trust store or proxy configuration."
+            )
+
+    return lines[-1]
 
 
 def ensure_wan22_installed() -> Tuple[bool, str, bool]:
@@ -38,8 +87,13 @@ def ensure_wan22_installed() -> Tuple[bool, str, bool]:
                 text=True,
             )
         except subprocess.CalledProcessError as exc:
-            output = exc.stderr.strip() or exc.stdout.strip() or str(exc)
-            return False, f"install failed: {output}", False
+            combined_output = "\n".join(
+                part.strip()
+                for part in (exc.stderr, exc.stdout)
+                if part and part.strip()
+            )
+            summary = _summarise_install_failure(combined_output or str(exc))
+            return False, f"install failed: {summary}", False
         except Exception as exc:  # pragma: no cover - runtime failures
             return False, f"install failed: {exc}", False
         importlib.invalidate_caches()

--- a/tests/test_wan_install.py
+++ b/tests/test_wan_install.py
@@ -1,0 +1,34 @@
+"""Tests for the Wan2.2 installation helper utilities."""
+
+from chargen import wan_install
+
+
+def test_summarise_install_failure_handles_http_403():
+    output = """
+    fatal: unable to access 'https://github.com/Wan-Video/Wan2.2.git/': CONNECT tunnel failed, response 403
+    error: subprocess-exited-with-error
+    """
+
+    message = wan_install._summarise_install_failure(output)  # noqa: SLF001 - testing helper
+
+    assert "HTTP 403" in message
+    assert "proxy" in message.lower()
+
+
+def test_summarise_install_failure_handles_missing_git():
+    output = "'git' is not recognized as an internal or external command, operable program or batch file."
+
+    message = wan_install._summarise_install_failure(output)  # noqa: SLF001 - testing helper
+
+    assert "Git does not" in message
+
+
+def test_summarise_install_failure_defaults_to_last_line():
+    output = """
+    some unrelated warning
+    ERROR: could not determine version
+    """
+
+    message = wan_install._summarise_install_failure(output)  # noqa: SLF001 - testing helper
+
+    assert message == "ERROR: could not determine version"


### PR DESCRIPTION
## Summary
- add heuristics to Wan2.2 installer so network and tooling errors return clearer messages
- extract helper utilities to normalise pip output for diagnosis
- add unit tests covering common installation failure scenarios

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d41cb35a5c832e8d2a36404ebf2965