### PR TITLE
Fix leftover merge marker in wan install helper

### DIFF
--- a/chargen/wan_install.py
+++ b/chargen/wan_install.py
@@ -57,7 +57,6 @@ def _summarise_install_failure(output: str) -> str:
                 "trust store or proxy configuration."
             )
 
-<
     return lines[-1]
 
 


### PR DESCRIPTION
## Summary
- remove a stray merge marker that prevented `_summarise_install_failure` from returning the final line

## Testing
- pytest tests/test_wan_install.py

------
https://chatgpt.com/codex/tasks/task_b_68d42b67ef08832ebe5aefd33bb6710b