### PR TITLE
Add shared device selector and log studio device

### DIFF
--- a/chargen/inpaint.py
+++ b/chargen/inpaint.py
@@ -14,6 +14,8 @@ import torch
 from PIL import Image, ImageOps
 from diffusers import StableDiffusionInpaintPipeline
 
+from tools.device import pick_device
+
 try:  # pragma: no cover - optional dependency in some builds
     from tools.cache import Cache
 except Exception:  # pragma: no cover - cache support is optional
@@ -69,21 +71,6 @@ def _prep_mask(mask: Image.Image, threshold: Optional[float] = None) -> Image.Im
     else:
         mask = mask.convert("L")
     return mask
-
-
-def pick_device() -> torch.device:
-    if torch.cuda.is_available():
-        return torch.device("cuda")
-    if os.environ.get("ZLUDA_PATH") or os.environ.get("ZKLUDA_PATH"):
-        return torch.device("cuda")
-    try:
-        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-            return torch.device("mps")
-    except Exception:  # pragma: no cover - dependent on torch build
-        pass
-    return torch.device("cpu")
-
-
 def pick_dtype(device: torch.device) -> torch.dtype:
     if device.type in {"cuda", "mps"}:
         return torch.float16

--- a/tools/device.py
+++ b/tools/device.py
@@ -1,0 +1,39 @@
+"""Device selector for PixStu.
+
+Fallback chain:
+CUDA (NVIDIA) → ZLUDA (Intel/AMD CUDA shim) → MPS (Apple) → CPU
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+
+def pick_device() -> torch.device:
+    """Return the best available torch device for PixStu workloads."""
+
+    # 1) Native CUDA
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+
+    # 2) ZLUDA probe (Intel/AMD CUDA shim)
+    # Detect via env or preload hints
+    zluda_env = os.environ.get("ZLUDA_PATH") or os.environ.get("LD_PRELOAD", "")
+    if "zluda" in zluda_env.lower():
+        try:
+            if torch.backends.cuda.is_built():
+                return torch.device("cuda")
+        except Exception:  # pragma: no cover - backend probing best effort
+            pass
+
+    # 3) Apple MPS
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        return torch.device("mps")
+
+    # 4) Fallback: CPU
+    return torch.device("cpu")
+
+
+__all__ = ["pick_device"]


### PR DESCRIPTION
## Summary
- add a shared device selection helper that probes CUDA, ZLUDA, MPS, and CPU
- reuse the helper in the inpaint pipeline loader
- log the chosen device when the inpaint studio UI starts up

## Testing
- python -m compileall tools/device.py chargen/inpaint.py chargen/inpaint_studio.py

------
https://chatgpt.com/codex/tasks/task_b_68d45bcdcdbc832eb9e154b613361856