### PR TITLE
Refactor device detection to shared helper

### DIFF
--- a/chargen/hw_detect.py
+++ b/chargen/hw_detect.py
@@ -3,23 +3,21 @@ from __future__ import annotations
 import os
 from typing import Literal
 
-try:
-    import torch
-except Exception:  # pragma: no cover - optional dependency
-    torch = None  # type: ignore
+from tools.device import pick_device
 
 Device = Literal["cuda", "rocm", "mps", "cpu"]
 
 
 def detect_device() -> Device:
-    if torch is None:
-        return "cpu"
-    if torch.cuda.is_available():
-        if os.getenv("ZLUDA") or os.getenv("ZLUDA_DEVICE"):
+    device = pick_device()
+    device_type = getattr(device, "type", str(device))
+
+    if device_type == "cuda":
+        if os.getenv("ZLUDA") or os.getenv("ZLUDA_DEVICE") or os.getenv("ZKLUDA"):
             return "rocm"
         return "cuda"
-    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+
+    if device_type == "mps":
         return "mps"
-    if os.getenv("ZKLUDA"):
-        return "rocm"
+
     return "cpu"

--- a/chargen/inpaint.py
+++ b/chargen/inpaint.py
@@ -14,6 +14,8 @@ import torch
 from PIL import Image, ImageOps
 from diffusers import StableDiffusionInpaintPipeline
 
+from tools.device import pick_device
+
 try:  # pragma: no cover - optional dependency in some builds
     from tools.cache import Cache
 except Exception:  # pragma: no cover - cache support is optional
@@ -69,21 +71,6 @@ def _prep_mask(mask: Image.Image, threshold: Optional[float] = None) -> Image.Im
     else:
         mask = mask.convert("L")
     return mask
-
-
-def pick_device() -> torch.device:
-    if torch.cuda.is_available():
-        return torch.device("cuda")
-    if os.environ.get("ZLUDA_PATH") or os.environ.get("ZKLUDA_PATH"):
-        return torch.device("cuda")
-    try:
-        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-            return torch.device("mps")
-    except Exception:  # pragma: no cover - dependent on torch build
-        pass
-    return torch.device("cpu")
-
-
 def pick_dtype(device: torch.device) -> torch.dtype:
     if device.type in {"cuda", "mps"}:
         return torch.float16
@@ -193,7 +180,7 @@ def inpaint_region(
     pipe, device = _ensure_pipeline(model_id, disable_safety_checker)
 
     if seed is not None:
-        generator = torch.Generator(device=device.type)
+        generator = torch.Generator(device=device)
         generator.manual_seed(int(seed))
     else:
         generator = None

--- a/tools/device.py
+++ b/tools/device.py
@@ -1,0 +1,69 @@
+"""Hardware accelerator selection helpers."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any
+
+try:  # pragma: no cover - optional dependency in some environments
+    import torch
+except Exception:  # pragma: no cover - torch may not be installed yet
+    torch = None  # type: ignore
+
+
+class _CPUDevice:
+    """Lightweight torch.device stand-in when torch is unavailable."""
+
+    type = "cpu"
+    index = None
+
+    def __str__(self) -> str:  # pragma: no cover - simple data holder
+        return "cpu"
+
+    def __repr__(self) -> str:  # pragma: no cover - simple data holder
+        return "device(type='cpu')"
+
+
+_CPU_FALLBACK = _CPUDevice()
+
+
+def _has_env_flag(*names: str) -> bool:
+    return any(os.getenv(name) for name in names)
+
+
+@lru_cache(maxsize=None)
+def pick_device() -> Any:
+    """Select the best available torch device for model execution."""
+
+    if torch is None:
+        return _CPU_FALLBACK
+
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+
+    # Vendor-provided CUDA compatibility layers
+    if _has_env_flag("ZLUDA_PATH", "ZKLUDA_PATH", "ZLUDA", "ZLUDA_DEVICE", "ZKLUDA"):
+        return torch.device("cuda")
+
+    try:  # pragma: no cover - optional acceleration
+        import zluda  # type: ignore
+
+        return torch.device("cuda")
+    except Exception:  # pragma: no cover - dependency optional
+        pass
+
+    try:  # pragma: no cover - optional acceleration
+        import zkluda  # type: ignore
+
+        return torch.device("cuda")
+    except Exception:  # pragma: no cover - dependency optional
+        pass
+
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        return torch.device("mps")
+
+    return torch.device("cpu")
+
+
+__all__ = ["pick_device"]


### PR DESCRIPTION
## Summary
- add a shared `pick_device` helper under `tools.device`
- update generation, substitution, inpainting, and hardware detection code to consume the shared helper

## Testing
- pytest tests/test_character_generator.py

------
https://chatgpt.com/codex/tasks/task_b_68d45bd90f90832ea087e47b2f700313