### PR TITLE
Log selected device before launching demos

### DIFF
--- a/chargen/character_studio.py
+++ b/chargen/character_studio.py
@@ -30,7 +30,7 @@ def build_ui():
                 miss = missing_assets(preset_data)
                 if not miss:
                     return gr.update(visible=False, value="")
-                items = [f"<li>{os.path.basename(m['path'])} — ~{m['size_gb']} GB</li>" for m in miss if m.get('path')]
+                items = [f"<li>{os.path.basename(m['path'])}  ~{m['size_gb']} GB</li>" for m in miss if m.get('path')]
                 html = (
                     "<b>Missing assets:</b><ul>"
                     + "".join(items)
@@ -138,4 +138,7 @@ if __name__ == "__main__":
             print(warning)
     except Exception as exc:  # pragma: no cover
         print("[UI] Drift check skipped:", exc)
+    from tools.device import pick_device
+
+    print(f"[PixStu] Using device: {pick_device()}")
     demo.launch(server_name=os.getenv("PCS_SERVER_NAME", "127.0.0.1"), server_port=int(os.getenv("PCS_PORT", "7860")))

--- a/chargen/sprites/studio.py
+++ b/chargen/sprites/studio.py
@@ -124,6 +124,9 @@ __all__ = ["demo"]
 
 
 if __name__ == "__main__":  # pragma: no cover - convenience launch
+    from tools.device import pick_device
+
+    print(f"[PixStu] Using device: {pick_device()}")
     demo.launch(
         share=False,
         inbrowser=True,

--- a/deploy-pcs.ps1
+++ b/deploy-pcs.ps1
@@ -1,4 +1,4 @@
-# deploy-pcs.ps1 (Teams-safe) — minimal portable app (CPU by default)
+# deploy-pcs.ps1 (Teams-safe) â€” minimal portable app (CPU by default)
 $ErrorActionPreference = "Stop"
 $root = Get-Location
 
@@ -45,9 +45,11 @@ Set-Content -Encoding UTF8 -Path (Join-Path $root "configs\curated_models.json")
 $runpy = @'
 import os
 from chargen.studio import build_app
+from tools.device import pick_device
 
 port = int(os.getenv("PCS_PORT", "7860"))
 demo = build_app()
+print(f"[PixStu] Using device: {pick_device()}")
 demo.launch(share=False, inbrowser=True, server_name="127.0.0.1", server_port=port, show_error=True)
 '@
 Set-Content -Encoding UTF8 -Path (Join-Path $root "run_pcs.py") -Value $runpy
@@ -252,6 +254,9 @@ if __name__ == "__main__":
     port = int(os.getenv("PCS_PORT","7860"))
     os.environ["HF_HOME"] = os.path.join(PROJ, "hf_cache")
     os.environ["HF_HUB_DISABLE_SYMLINKS_WARNING"] = "1"
+    from tools.device import pick_device
+
+    print(f"[PixStu] Using device: {pick_device()}")
     demo.launch(share=False, inbrowser=True, server_name="127.0.0.1", server_port=port, show_error=True)
 '@
 Set-Content -Encoding UTF8 -Path (Join-Path $root "app\pixel_char_studio.py") -Value $app

--- a/run_sprite_sheet_studio.py
+++ b/run_sprite_sheet_studio.py
@@ -2,10 +2,12 @@ import os
 
 if __name__ == "__main__":
     from chargen.sprites.studio import demo
+    from tools.device import pick_device
 
     port = int(os.getenv("PCS_SPRITE_SHEET_PORT", "7865"))
     server_name = os.getenv("PCS_SERVER_NAME", "127.0.0.1")
     open_browser = os.getenv("PCS_OPEN_BROWSER", "0").lower() in {"1", "true", "yes", "on"}
+    print(f"[PixStu] Using device: {pick_device()}")
     demo.launch(
         share=False,
         inbrowser=open_browser,


### PR DESCRIPTION
## Summary
- print the selected execution device before launching the sprite sheet studio entry point
- surface the device selection message when running the sprite studio UI directly
- mirror the device logging in the main character studio and portable launcher scripts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d45be169b8832e9741b30f194bbc02