### PR TITLE
Rewrite PixStu studio for v2.2.0-pre pipelines

### DIFF
--- a/SUCCESSOR_NOTE_v2.2.md
+++ b/SUCCESSOR_NOTE_v2.2.md
@@ -1,0 +1,14 @@
+# PixStu v2.2.0-pre Successor Note
+
+## New
+- Pipelines: txt2img, img2img, inpainting, txt2gif
+- Retro-modern UI tabs for each
+- Guardrails, cache, device fallback, self-heal retained
+
+## Quickstart
+pip install pillow gradio huggingface_hub imageio
+# Optional GPU:
+# pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+# pip install diffusers transformers accelerate xformers
+
+python -m pixstu.app.studio

--- a/pixstu/__init__.py
+++ b/pixstu/__init__.py
@@ -1,5 +1,5 @@
 """
-PixStu v2.1.0 — Pixel Character Studio
+PixStu v2.2.0-pre — Pixel Character Studio
 """
 from .tools.version import VERSION
 

--- a/pixstu/app/studio.py
+++ b/pixstu/app/studio.py
@@ -1,26 +1,25 @@
 """
-Retro UI with Inpainting, Gallery, Downloads tabs.
+Retro-modern UI with tabs: Inpainting, Img2Img, Txt2Img, Txt2GIF, Gallery, Downloads.
 """
 from __future__ import annotations
 
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
-codex/rewrite-pixstu-to-version-2.1.0-bq3zn7
 try:  # optional dependency guardrail
     import gradio as gr
-except ModuleNotFoundError as exc:  # pragma: no cover - exercised in minimal envs
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised when gradio missing
     gr = None  # type: ignore[assignment]
     _GRADIO_IMPORT_ERROR = exc
 else:
     _GRADIO_IMPORT_ERROR = None
-=======
-import gradio as gr
-main
 
+from ..core.img2img import img2img
 from ..core.inpaint import inpaint
+from ..core.txt2img import txt2img
+from ..core.txt2vid import txt2gif
 from ..tools.device import pick_device
 from ..tools.downloads import download_lora, have_lora
 from ..tools.self_heal import self_heal
@@ -36,6 +35,17 @@ def _safe_stem(text: str | None) -> str:
     return base or datetime.now().strftime("%Y%m%d%H%M%S")
 
 
+def _save(image, prompt: str | None) -> None:
+    if image is None:
+        return
+    stem = _safe_stem(prompt)
+    target = GALLERY / f"{stem}.png"
+    try:
+        image.save(target)
+    except Exception:
+        pass
+
+
 def _gallery() -> List[str]:
     return [
         str(path)
@@ -49,51 +59,84 @@ def _scan_presets() -> List[str]:
     if not cfg.exists():
         return []
     try:
-        data = json.loads(cfg.read_text(encoding="utf-8"))
-        return [item["lora"] for item in data if isinstance(item, dict) and "lora" in item]
+        payload = json.loads(cfg.read_text(encoding="utf-8"))
     except Exception:
         return []
+    return [item["lora"] for item in payload if isinstance(item, dict) and "lora" in item]
 
 
-def _run_inpaint(prompt, init, mask, steps, scale, seed):
-    image, meta = inpaint(prompt, init, mask, steps, scale, seed)
-    if image:
-        stem = _safe_stem(prompt)
-        dest = GALLERY / f"{stem}.png"
-        image.save(dest)
-    return image, _gallery()
+def _run_txt2img(prompt: str):
+    image, _ = txt2img(prompt)
+    _save(image, prompt)
+    return image
+
+
+def _run_img2img(prompt: str, init: str):
+    image, _ = img2img(prompt, init)
+    _save(image, prompt)
+    return image
+
+
+def _run_inpaint(prompt: str, init: str, mask: str):
+    image, _ = inpaint(prompt, init, mask)
+    _save(image, prompt)
+    return image
+
+
+def _run_txt2gif(prompt: str) -> Tuple[object, str]:
+    image, meta = txt2gif(prompt)
+    _save(image, prompt)
+    return image, meta.get("gif_b64", "")
 
 
 def studio():
-codex/rewrite-pixstu-to-version-2.1.0-bq3zn7
     if gr is None:  # pragma: no cover - requires missing dependency
         raise RuntimeError(
             "PixStu studio requires the optional dependency 'gradio'. Install it with "
             "`pip install -r requirements.txt` (or `pip install gradio`) before running the UI."
         ) from _GRADIO_IMPORT_ERROR
 
-=======
-main
-    with gr.Blocks(css=".retro-btn{font-family:monospace;background:#333;color:#fff;border:2px solid #ff66cc}") as demo:
+    with gr.Blocks(
+        css=".retro-btn{font-family:monospace;background:#333;color:#fff;border:2px solid #ff66cc}"
+    ) as demo:
         gr.Markdown(f"## 🕹️ PixStu v{VERSION} — Device: **{pick_device()}**")
+
+        with gr.Tab("✍️ Txt2Img"):
+            prompt = gr.Textbox(label="Prompt")
+            run = gr.Button("▶️ Txt2Img", elem_classes="retro-btn")
+            out = gr.Image(label="Output")
+            run.click(_run_txt2img, inputs=prompt, outputs=out)
+
+        with gr.Tab("🖌️ Img2Img"):
+            prompt = gr.Textbox(label="Prompt")
+            init = gr.Image(type="filepath", label="Init Image")
+            run = gr.Button("▶️ Img2Img", elem_classes="retro-btn")
+            out = gr.Image(label="Output")
+            run.click(_run_img2img, inputs=[prompt, init], outputs=out)
+
         with gr.Tab("🎨 Inpainting"):
             prompt = gr.Textbox(label="Prompt")
-            init = gr.Image(type="filepath", label="Init")
+            init = gr.Image(type="filepath", label="Init Image")
             mask = gr.Image(type="filepath", label="Mask")
-            steps = gr.Slider(1, 100, 40, label="Steps")
-            scale = gr.Slider(0, 20, 7.5, label="Guidance Scale")
-            seed = gr.Number(label="Seed")
-            run = gr.Button("▶️ Run", elem_classes="retro-btn")
+            run = gr.Button("▶️ Inpaint", elem_classes="retro-btn")
             out = gr.Image(label="Output")
-            gal = gr.Gallery(value=_gallery(), label="Recent")
-            run.click(_run_inpaint, [prompt, init, mask, steps, scale, seed], [out, gal])
+            run.click(_run_inpaint, inputs=[prompt, init, mask], outputs=out)
+
+        with gr.Tab("🎞️ Txt2GIF"):
+            prompt = gr.Textbox(label="Prompt")
+            run = gr.Button("▶️ Gif", elem_classes="retro-btn")
+            preview = gr.Image(label="Preview")
+            payload = gr.Textbox(label="GIF (base64)")
+            run.click(_run_txt2gif, inputs=prompt, outputs=[preview, payload])
+
         with gr.Tab("🖼️ Gallery"):
-            gallery = gr.Gallery(value=_gallery(), label="Saved")
-            gr.Button("🔄 Refresh").click(_gallery, outputs=gallery)
+            gallery = gr.Gallery(value=_gallery(), label="Recent")
+            gr.Button("🔄 Refresh", elem_classes="retro-btn").click(_gallery, outputs=gallery)
+
         with gr.Tab("📥 Downloads"):
-            scan = gr.Button("🔍 Scan Presets")
-            download = gr.Button("⬇️ Download Missing")
-            box = gr.Textbox(label="Missing LoRAs")
+            scan = gr.Button("🔍 Scan Presets", elem_classes="retro-btn")
+            download = gr.Button("⬇️ Download Missing", elem_classes="retro-btn")
+            box = gr.Textbox(label="Missing LoRAs", lines=8)
 
             def _missing():
                 missing = [name for name in _scan_presets() if not have_lora(name)]
@@ -114,11 +157,4 @@ main
 
 
 if __name__ == "__main__":  # pragma: no cover - manual launch
-codex/rewrite-pixstu-to-version-2.1.0-bq3zn7
-    try:
-        studio().launch()
-    except RuntimeError as exc:
-        raise SystemExit(str(exc)) from exc
-=======
     studio().launch()
-main

--- a/pixstu/core/img2img.py
+++ b/pixstu/core/img2img.py
@@ -1,0 +1,162 @@
+"""
+Image-to-Image pipeline (no mask).
+"""
+from __future__ import annotations
+
+import json
+import random
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from PIL import Image, ImageDraw
+
+from ..tools.cache import Cache
+from ..tools.device import pick_device
+from ..tools.guardrails import check_blank_background, check_prompt
+from .lora import prepare_lora_kwargs
+
+try:  # optional heavy deps
+    import torch
+    from diffusers import StableDiffusionXLImg2ImgPipeline
+except Exception:  # pragma: no cover - exercised when deps missing
+    torch = None  # type: ignore[assignment]
+    StableDiffusionXLImg2ImgPipeline = None  # type: ignore[assignment]
+
+ImageLike = Union[str, Path, Image.Image]
+
+
+def _seed(seed: Optional[int]) -> None:
+    if seed is None:
+        return
+    random.seed(seed)
+    try:
+        import numpy as np  # type: ignore
+
+        np.random.seed(seed)
+    except Exception:
+        pass
+    if torch is not None:
+        torch.manual_seed(seed)
+
+
+def _read(image: ImageLike) -> Image.Image:
+    if isinstance(image, Image.Image):
+        return image.convert("RGBA")
+    return Image.open(image).convert("RGBA")
+
+
+def _cache_key(**payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+def _image_stamp(src: ImageLike) -> Optional[str]:
+    if isinstance(src, (str, Path)):
+        path = Path(src)
+        try:
+            return f"{path.resolve()}@{path.stat().st_mtime_ns}"
+        except Exception:
+            return str(path.resolve())
+    return None
+
+
+def _fallback(base: Image.Image) -> Image.Image:
+    out = base.copy()
+    ImageDraw.Draw(out).rectangle([(10, 10), (min(base.width, 100), min(base.height, 100))], outline=(0, 255, 255, 255), width=3)
+    return out
+
+
+def img2img(
+    prompt: str,
+    init_image: ImageLike,
+    strength: float = 0.65,
+    steps: int = 40,
+    guidance_scale: float = 7.5,
+    seed: Optional[int] = None,
+    negative: str = "",
+    loras: Optional[List[Tuple[str, float]]] = None,
+    dtype: Optional[str] = None,
+    disable_safety_checker: bool = False,
+) -> Tuple[Image.Image, Dict[str, Any]]:
+    start = time.time()
+    check_prompt(prompt)
+    init = _read(init_image)
+    _seed(seed)
+
+    stamp = _image_stamp(init_image)
+    key = _cache_key(
+        prompt=prompt,
+        negative=negative,
+        strength=float(strength),
+        steps=int(steps),
+        guidance=float(guidance_scale),
+        seed=seed,
+        loras=loras or [],
+        dtype=dtype,
+        init=stamp,
+    )
+
+    if stamp is not None:
+        with Cache("img2img", ttl=int(12 * 3600)) as cache:
+            cached = cache.get_image(key)
+            if cached is not None:
+                check_blank_background(cached)
+                return cached, {
+                    "prompt": prompt,
+                    "device": "cached",
+                    "seed": seed,
+                    "duration_s": 0.0,
+                }
+
+    if torch is None or StableDiffusionXLImg2ImgPipeline is None:
+        image = _fallback(init)
+        check_blank_background(image)
+        return image, {
+            "prompt": prompt,
+            "device": "stub",
+            "seed": seed,
+            "duration_s": time.time() - start,
+        }
+
+    device = pick_device()
+    use_fp16 = dtype == "float16" or (dtype is None and getattr(device, "type", "") == "cuda")
+    torch_dtype = torch.float16 if use_fp16 else torch.float32  # type: ignore[attr-defined]
+
+    pipe = StableDiffusionXLImg2ImgPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch_dtype,
+    ).to(device)
+
+    if disable_safety_checker:
+        pipe.safety_checker = None
+
+    generator = None
+    if seed is not None:
+        generator = torch.Generator(device=device).manual_seed(seed)
+
+    lora_kwargs = prepare_lora_kwargs(loras or []) if loras else {}
+
+    result = pipe(
+        prompt=prompt,
+        image=init.convert("RGB"),
+        strength=float(strength),
+        num_inference_steps=int(steps),
+        guidance_scale=float(guidance_scale),
+        negative_prompt=negative or None,
+        generator=generator,
+        **lora_kwargs,
+    )
+
+    image = result.images[0].convert("RGBA")
+    check_blank_background(image)
+
+    if stamp is not None:
+        with Cache("img2img", ttl=int(12 * 3600)) as cache:
+            cache.put_image(key, image)
+
+    return image, {
+        "prompt": prompt,
+        "device": str(device),
+        "seed": seed,
+        "duration_s": time.time() - start,
+    }

--- a/pixstu/core/txt2img.py
+++ b/pixstu/core/txt2img.py
@@ -1,0 +1,145 @@
+"""
+Text-to-Image pipeline with graceful fallback.
+"""
+from __future__ import annotations
+
+import json
+import random
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from PIL import Image, ImageDraw
+
+from ..tools.cache import Cache
+from ..tools.device import pick_device
+from ..tools.guardrails import check_blank_background, check_prompt
+from .lora import prepare_lora_kwargs
+
+try:  # optional heavy deps
+    import torch
+    from diffusers import StableDiffusionXLPipeline
+except Exception:  # pragma: no cover - exercised when deps missing
+    torch = None  # type: ignore[assignment]
+    StableDiffusionXLPipeline = None  # type: ignore[assignment]
+
+
+def _seed(seed: Optional[int]) -> None:
+    if seed is None:
+        return
+    random.seed(seed)
+    try:
+        import numpy as np  # type: ignore
+
+        np.random.seed(seed)
+    except Exception:
+        pass
+    if torch is not None:
+        torch.manual_seed(seed)
+
+
+def _cache_key(**payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+def _fallback(width: int, height: int) -> Image.Image:
+    image = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(image)
+    margin = 10
+    draw.rectangle(
+        [(margin, margin), (width - margin, height - margin)],
+        outline=(255, 0, 255, 255),
+        width=3,
+    )
+    return image
+
+
+def txt2img(
+    prompt: str,
+    negative: str = "",
+    steps: int = 40,
+    guidance_scale: float = 7.5,
+    width: int = 768,
+    height: int = 768,
+    seed: Optional[int] = None,
+    loras: Optional[List[Tuple[str, float]]] = None,
+    dtype: Optional[str] = None,
+    disable_safety_checker: bool = False,
+) -> Tuple[Image.Image, Dict[str, Any]]:
+    start = time.time()
+    check_prompt(prompt)
+    _seed(seed)
+
+    key = _cache_key(
+        prompt=prompt,
+        negative=negative,
+        steps=int(steps),
+        guidance=float(guidance_scale),
+        width=int(width),
+        height=int(height),
+        seed=seed,
+        loras=loras or [],
+        dtype=dtype,
+    )
+
+    with Cache("txt2img", ttl=int(12 * 3600)) as cache:
+        cached = cache.get_image(key)
+        if cached is not None:
+            check_blank_background(cached)
+            return cached, {
+                "prompt": prompt,
+                "device": "cached",
+                "seed": seed,
+                "duration_s": 0.0,
+            }
+
+    if torch is None or StableDiffusionXLPipeline is None:
+        image = _fallback(int(width), int(height))
+        check_blank_background(image)
+        return image, {
+            "prompt": prompt,
+            "device": "stub",
+            "seed": seed,
+            "duration_s": time.time() - start,
+        }
+
+    device = pick_device()
+    use_fp16 = dtype == "float16" or (dtype is None and getattr(device, "type", "") == "cuda")
+    torch_dtype = torch.float16 if use_fp16 else torch.float32  # type: ignore[attr-defined]
+
+    pipe = StableDiffusionXLPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch_dtype,
+    ).to(device)
+
+    if disable_safety_checker:
+        pipe.safety_checker = None
+
+    generator = None
+    if seed is not None:
+        generator = torch.Generator(device=device).manual_seed(seed)
+
+    lora_kwargs = prepare_lora_kwargs(loras or []) if loras else {}
+
+    result = pipe(
+        prompt=prompt,
+        negative_prompt=negative or None,
+        num_inference_steps=int(steps),
+        guidance_scale=float(guidance_scale),
+        width=int(width),
+        height=int(height),
+        generator=generator,
+        **lora_kwargs,
+    )
+
+    image = result.images[0].convert("RGBA")
+    check_blank_background(image)
+
+    with Cache("txt2img", ttl=int(12 * 3600)) as cache:
+        cache.put_image(key, image)
+
+    return image, {
+        "prompt": prompt,
+        "device": str(device),
+        "seed": seed,
+        "duration_s": time.time() - start,
+    }

--- a/pixstu/core/txt2vid.py
+++ b/pixstu/core/txt2vid.py
@@ -1,0 +1,56 @@
+"""
+Text-to-GIF pipeline: jitter txt2img frames into a GIF.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import random
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from PIL import Image
+
+from .txt2img import txt2img
+
+try:  # optional dependency
+    import imageio.v2 as imageio
+except Exception:  # pragma: no cover - exercised when dependency missing
+    imageio = None  # type: ignore[assignment]
+
+
+def txt2gif(
+    prompt: str,
+    frames: int = 12,
+    duration_ms: int = 100,
+    seed: Optional[int] = None,
+) -> Tuple[Image.Image, Dict[str, Any]]:
+    start = time.time()
+    rng = random.Random(seed)
+    images: List[Image.Image] = []
+
+    for index in range(max(1, int(frames))):
+        frame_prompt = f"{prompt}, frame {index + 1}"
+        frame_seed = None if seed is None else seed + index + rng.randint(0, 3)
+        image, _ = txt2img(frame_prompt, seed=frame_seed)
+        images.append(image)
+
+    gif_b64 = ""
+    if imageio is not None and len(images) > 1:
+        buffer = io.BytesIO()
+        imageio.mimsave(
+            buffer,
+            [im.convert("RGBA") for im in images],
+            format="GIF",
+            duration=max(1, int(duration_ms)) / 1000.0,
+        )
+        gif_b64 = base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+    return images[0], {
+        "prompt": prompt,
+        "frames": len(images),
+        "duration_ms": int(duration_ms),
+        "seed": seed,
+        "duration_s": time.time() - start,
+        "gif_b64": gif_b64,
+    }

--- a/pixstu/tools/device.py
+++ b/pixstu/tools/device.py
@@ -1,22 +1,16 @@
-codex/rewrite-pixstu-to-version-2.1.0-bq3zn7
-"""Device selector with fallback: CUDA → ZLUDA → MPS → CPU."""
+"""
+Device selector with fallback:
+CUDA (NVIDIA) → ZLUDA (Intel/AMD CUDA shim) → MPS (Apple) → CPU
+"""
 from __future__ import annotations
 
 import os
 from typing import Union
 
-try:  # optional dependency
+try:  # torch is optional for CPU-only installs
     import torch
-except ModuleNotFoundError:  # pragma: no cover - exercised without torch installed
+except ModuleNotFoundError:  # pragma: no cover - exercised without torch
     torch = None  # type: ignore[assignment]
-=======
-"""
-Device selector with fallback:
-CUDA (NVIDIA) → ZLUDA (Intel/AMD CUDA shim) → MPS (Apple) → CPU
-"""
-import os
-import torch
-main
 
 
 def _zluda_hint() -> str:
@@ -28,14 +22,10 @@ def _zluda_hint() -> str:
     return env.lower()
 
 
-codex/rewrite-pixstu-to-version-2.1.0-bq3zn7
 def pick_device() -> Union["torch.device", str]:
     if torch is None:
         return "cpu"
 
-=======
-def pick_device() -> torch.device:
-main
     if torch.cuda.is_available():
         return torch.device("cuda")
 
@@ -46,16 +36,8 @@ main
         except Exception:
             pass
 
-codex/rewrite-pixstu-to-version-2.1.0-bq3zn7
     mps_backend = getattr(torch.backends, "mps", None)
     if mps_backend and getattr(mps_backend, "is_available", lambda: False)():
         return torch.device("mps")
 
-    return torch.device("cpu") if torch is not None else "cpu"
-=======
-    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
-        return torch.device("mps")
-
     return torch.device("cpu")
- main
-

--- a/pixstu/tools/version.py
+++ b/pixstu/tools/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.1.0"
+VERSION = "2.2.0-pre"


### PR DESCRIPTION
## Summary
- add Stable Diffusion XL txt2img, img2img, and txt2gif pipelines with cache-backed fallbacks
- refresh the Gradio studio with retro tabs for each pipeline plus downloads guardrails
- bump PixStu to v2.2.0-pre and document the release in a new successor note

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_68d5b01b3948832eb7c17ec573d23889