### PR TITLE
Align device selector with hotfix spec

### DIFF
--- a/pixstu/tools/device.py
+++ b/pixstu/tools/device.py
@@ -3,16 +3,10 @@ Device selector with fallback:
 CUDA (NVIDIA) → ZLUDA (Intel/AMD CUDA shim) → MPS (Apple) → CPU
 """
 import os
-
-try:
-    import torch
-except ModuleNotFoundError:  # pragma: no cover - optional install path
-    torch = None  # type: ignore[assignment]
+import torch
 
 
 def pick_device():
-    if torch is None:
-        return "cpu"
     # 1) Native CUDA
     if torch.cuda.is_available():
         return torch.device("cuda")


### PR DESCRIPTION
## Summary
- import torch unconditionally in the device selector to follow the hotfix spec
- keep the CUDA/ZLUDA/MPS/CPU fallback logic intact for consistency across modules

## Testing
- python -m compileall pixstu

------
https://chatgpt.com/codex/tasks/task_b_68d698800e3c832eaa496164072921a3